### PR TITLE
Updates to OAuth2 related values, suggested by @frett

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,14 +1,5 @@
-source "https://github.com/GlobalTechnology/cocoapods-specs.git"
-
 platform :ios, '7.0'
 
-
 target "TheKeyOAuth2" do
-  pod 'gtm-oauth2-thekey', '~>1.0'
-end
-
-post_install do |installer|
-    installer.pods_project.build_configuration_list.build_configurations.each do |configuration|
-        configuration.build_settings['CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES'] = 'YES'
-    end
+  pod 'GTMOAuth2'
 end

--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,14 @@
+source "https://github.com/GlobalTechnology/cocoapods-specs.git"
+
 platform :ios, '7.0'
 
-pod 'gtm-oauth2-thekey', '~>1.0'
 
+target "TheKeyOAuth2" do
+  pod 'gtm-oauth2-thekey', '~>1.0'
+end
+
+post_install do |installer|
+    installer.pods_project.build_configuration_list.build_configurations.each do |configuration|
+        configuration.build_settings['CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES'] = 'YES'
+    end
+end

--- a/TheKeyOAuth2.podspec
+++ b/TheKeyOAuth2.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name         = "TheKeyOAuth2"
-  s.version      = "0.5.3"
+  s.version      = "0.6.0"
   s.summary      = "TheKey OAuth2 Client Library."
   s.homepage     = "http://thekey.me/"
   s.license      = { :type => 'Modified BSD', :file => 'LICENSE.txt' }
   s.author       = { "Brian Zoetewey" => "brian.zoetewey@ccci.org" }
-  s.source       = { :git => "git@github.com:GlobalTechnology/TheKeyOAuth2.git", :tag => "0.5.3" }
+  s.source       = { :git => "git@github.com:GlobalTechnology/TheKeyOAuth2.git", :tag => "0.6.0" }
   s.platform     = :ios, '7.0'
   s.source_files = 'TheKeyOAuth2/*.{h,m}'
   s.public_header_files = 'TheKeyOAuth2/TheKeyOAuth2Client.h, TheKeyOAuth2LoginViewController.h'

--- a/TheKeyOAuth2.podspec
+++ b/TheKeyOAuth2.podspec
@@ -1,14 +1,14 @@
 Pod::Spec.new do |s|
   s.name         = "TheKeyOAuth2"
-  s.version      = "0.6.0"
+  s.version      = "0.6.1"
   s.summary      = "TheKey OAuth2 Client Library."
   s.homepage     = "http://thekey.me/"
   s.license      = { :type => 'Modified BSD', :file => 'LICENSE.txt' }
   s.author       = { "Brian Zoetewey" => "brian.zoetewey@ccci.org" }
-  s.source       = { :git => "git@github.com:GlobalTechnology/TheKeyOAuth2.git", :tag => "0.6.0" }
+  s.source       = { :git => "git@github.com:GlobalTechnology/TheKeyOAuth2.git", :tag => "0.6.1" }
   s.platform     = :ios, '7.0'
   s.source_files = 'TheKeyOAuth2/*.{h,m}'
-  s.public_header_files = 'TheKeyOAuth2/TheKeyOAuth2Client.h, TheKeyOAuth2LoginViewController.h'
+  s.public_header_files = "TheKeyOAuth2/TheKeyOAuth2Client.h", "TheKeyOAuth2/TheKeyOAuth2LoginViewController.h"
   s.requires_arc = true
   s.dependency 'gtm-oauth2-thekey', '~> 1.0'
 end

--- a/TheKeyOAuth2.podspec
+++ b/TheKeyOAuth2.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name         = "TheKeyOAuth2"
-  s.version      = "0.6.2"
+  s.version      = "0.6.3"
   s.summary      = "TheKey OAuth2 Client Library."
   s.homepage     = "http://thekey.me/"
   s.license      = { :type => 'Modified BSD', :file => 'LICENSE.txt' }
   s.author       = { "Brian Zoetewey" => "brian.zoetewey@ccci.org" }
-  s.source       = { :git => "git@github.com:GlobalTechnology/TheKeyOAuth2.git", :tag => "0.6.2" }
+  s.source       = { :git => "git@github.com:GlobalTechnology/TheKeyOAuth2.git", :tag => "0.6.3" }
   s.platform     = :ios, '7.0'
   s.source_files = 'TheKeyOAuth2/*.{h,m}'
   s.public_header_files = "TheKeyOAuth2/TheKeyOAuth2Client.h", "TheKeyOAuth2/TheKeyOAuth2LoginViewController.h"

--- a/TheKeyOAuth2.podspec
+++ b/TheKeyOAuth2.podspec
@@ -1,15 +1,15 @@
 Pod::Spec.new do |s|
   s.name         = "TheKeyOAuth2"
-  s.version      = "0.6.1"
+  s.version      = "0.6.2"
   s.summary      = "TheKey OAuth2 Client Library."
   s.homepage     = "http://thekey.me/"
   s.license      = { :type => 'Modified BSD', :file => 'LICENSE.txt' }
   s.author       = { "Brian Zoetewey" => "brian.zoetewey@ccci.org" }
-  s.source       = { :git => "git@github.com:GlobalTechnology/TheKeyOAuth2.git", :tag => "0.6.1" }
+  s.source       = { :git => "git@github.com:GlobalTechnology/TheKeyOAuth2.git", :tag => "0.6.2" }
   s.platform     = :ios, '7.0'
   s.source_files = 'TheKeyOAuth2/*.{h,m}'
   s.public_header_files = "TheKeyOAuth2/TheKeyOAuth2Client.h", "TheKeyOAuth2/TheKeyOAuth2LoginViewController.h"
   s.requires_arc = true
-  s.dependency 'gtm-oauth2-thekey', '~> 1.0'
+  s.dependency 'GTMOAuth2', '~> 1.1.1'
 end
 

--- a/TheKeyOAuth2.xcodeproj/project.pbxproj
+++ b/TheKeyOAuth2.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		7A101B10BF724D759B1EEB6B /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CBEB0AEA9BB74A64BB7CDF39 /* libPods.a */; };
+		B53FC24BD01A6359EE0F873B /* Pods_TheKeyOAuth2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02E29249FB5613E34D34ED19 /* Pods_TheKeyOAuth2.framework */; };
 		D3BAC3AF1836AD9500EDE24A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D3BAC3AE1836AD9500EDE24A /* Foundation.framework */; };
 		D3BAC3D61836AF7C00EDE24A /* TheKeyOAuth2Client.m in Sources */ = {isa = PBXBuildFile; fileRef = D3BAC3D51836AF7C00EDE24A /* TheKeyOAuth2Client.m */; };
 		D3C4033C183BE939002F364E /* TheKeyOAuth2LoginViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D3C4033B183BE939002F364E /* TheKeyOAuth2LoginViewController.m */; };
@@ -26,7 +26,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		BE0078DC8AA64880B9E7E2A0 /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = "<group>"; };
+		02E29249FB5613E34D34ED19 /* Pods_TheKeyOAuth2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TheKeyOAuth2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AE3262F8F81A51B264ED0E2B /* Pods-TheKeyOAuth2.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TheKeyOAuth2.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TheKeyOAuth2/Pods-TheKeyOAuth2.debug.xcconfig"; sourceTree = "<group>"; };
 		CBEB0AEA9BB74A64BB7CDF39 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3BAC3AB1836AD9500EDE24A /* libTheKeyOAuth2.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libTheKeyOAuth2.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3BAC3AE1836AD9500EDE24A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -37,6 +38,7 @@
 		D3BAC3D51836AF7C00EDE24A /* TheKeyOAuth2Client.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TheKeyOAuth2Client.m; sourceTree = "<group>"; };
 		D3C4033A183BE939002F364E /* TheKeyOAuth2LoginViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TheKeyOAuth2LoginViewController.h; sourceTree = "<group>"; };
 		D3C4033B183BE939002F364E /* TheKeyOAuth2LoginViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TheKeyOAuth2LoginViewController.m; sourceTree = "<group>"; };
+		E8B0B05FD0B9E5DDA3CC3A19 /* Pods-TheKeyOAuth2.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TheKeyOAuth2.release.xcconfig"; path = "Pods/Target Support Files/Pods-TheKeyOAuth2/Pods-TheKeyOAuth2.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -45,20 +47,29 @@
 			buildActionMask = 2147483647;
 			files = (
 				D3BAC3AF1836AD9500EDE24A /* Foundation.framework in Frameworks */,
-				7A101B10BF724D759B1EEB6B /* libPods.a in Frameworks */,
+				B53FC24BD01A6359EE0F873B /* Pods_TheKeyOAuth2.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4169491AECF0D1CAD99D0D5D /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				AE3262F8F81A51B264ED0E2B /* Pods-TheKeyOAuth2.debug.xcconfig */,
+				E8B0B05FD0B9E5DDA3CC3A19 /* Pods-TheKeyOAuth2.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 		D3BAC3A21836AD9500EDE24A = {
 			isa = PBXGroup;
 			children = (
 				D3BAC3B01836AD9500EDE24A /* TheKeyOAuth2 */,
 				D3BAC3AD1836AD9500EDE24A /* Frameworks */,
 				D3BAC3AC1836AD9500EDE24A /* Products */,
-				BE0078DC8AA64880B9E7E2A0 /* Pods.xcconfig */,
+				4169491AECF0D1CAD99D0D5D /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -77,6 +88,7 @@
 				D3BAC3BC1836AD9500EDE24A /* XCTest.framework */,
 				D3BAC3BF1836AD9500EDE24A /* UIKit.framework */,
 				CBEB0AEA9BB74A64BB7CDF39 /* libPods.a */,
+				02E29249FB5613E34D34ED19 /* Pods_TheKeyOAuth2.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -108,11 +120,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = D3BAC3CE1836AD9500EDE24A /* Build configuration list for PBXNativeTarget "TheKeyOAuth2" */;
 			buildPhases = (
-				BEEE5FF830584B0794EDB5F7 /* Check Pods Manifest.lock */,
+				BEEE5FF830584B0794EDB5F7 /* 📦 Check Pods Manifest.lock */,
 				D3BAC3A71836AD9500EDE24A /* Sources */,
 				D3BAC3A81836AD9500EDE24A /* Frameworks */,
 				D3BAC3A91836AD9500EDE24A /* CopyFiles */,
-				67B279841A2045DEAA9D9512 /* Copy Pods Resources */,
+				67B279841A2045DEAA9D9512 /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -150,29 +162,29 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		67B279841A2045DEAA9D9512 /* Copy Pods Resources */ = {
+		67B279841A2045DEAA9D9512 /* 📦 Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "📦 Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Pods-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TheKeyOAuth2/Pods-TheKeyOAuth2-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		BEEE5FF830584B0794EDB5F7 /* Check Pods Manifest.lock */ = {
+		BEEE5FF830584B0794EDB5F7 /* 📦 Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -267,12 +279,16 @@
 		};
 		D3BAC3CF1836AD9500EDE24A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BE0078DC8AA64880B9E7E2A0 /* Pods.xcconfig */;
+			baseConfigurationReference = AE3262F8F81A51B264ED0E2B /* Pods-TheKeyOAuth2.debug.xcconfig */;
 			buildSettings = {
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				DSTROOT = /tmp/TheKeyOAuth2.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "TheKeyOAuth2/TheKeyOAuth2-Prefix.pch";
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"$(inherited)",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};
@@ -280,12 +296,16 @@
 		};
 		D3BAC3D01836AD9500EDE24A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BE0078DC8AA64880B9E7E2A0 /* Pods.xcconfig */;
+			baseConfigurationReference = E8B0B05FD0B9E5DDA3CC3A19 /* Pods-TheKeyOAuth2.release.xcconfig */;
 			buildSettings = {
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				DSTROOT = /tmp/TheKeyOAuth2.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "TheKeyOAuth2/TheKeyOAuth2-Prefix.pch";
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"$(inherited)",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};

--- a/TheKeyOAuth2.xcodeproj/project.pbxproj
+++ b/TheKeyOAuth2.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		B53FC24BD01A6359EE0F873B /* Pods_TheKeyOAuth2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02E29249FB5613E34D34ED19 /* Pods_TheKeyOAuth2.framework */; };
+		1A5DD09361E3DD20E61CEB3E /* libPods-TheKeyOAuth2.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DFA7ABA8C5C33723E52B498 /* libPods-TheKeyOAuth2.a */; };
 		D3BAC3AF1836AD9500EDE24A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D3BAC3AE1836AD9500EDE24A /* Foundation.framework */; };
 		D3BAC3D61836AF7C00EDE24A /* TheKeyOAuth2Client.m in Sources */ = {isa = PBXBuildFile; fileRef = D3BAC3D51836AF7C00EDE24A /* TheKeyOAuth2Client.m */; };
 		D3C4033C183BE939002F364E /* TheKeyOAuth2LoginViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D3C4033B183BE939002F364E /* TheKeyOAuth2LoginViewController.m */; };
@@ -26,7 +26,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		02E29249FB5613E34D34ED19 /* Pods_TheKeyOAuth2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TheKeyOAuth2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5DFA7ABA8C5C33723E52B498 /* libPods-TheKeyOAuth2.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TheKeyOAuth2.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE3262F8F81A51B264ED0E2B /* Pods-TheKeyOAuth2.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TheKeyOAuth2.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TheKeyOAuth2/Pods-TheKeyOAuth2.debug.xcconfig"; sourceTree = "<group>"; };
 		CBEB0AEA9BB74A64BB7CDF39 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3BAC3AB1836AD9500EDE24A /* libTheKeyOAuth2.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libTheKeyOAuth2.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -47,7 +47,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D3BAC3AF1836AD9500EDE24A /* Foundation.framework in Frameworks */,
-				B53FC24BD01A6359EE0F873B /* Pods_TheKeyOAuth2.framework in Frameworks */,
+				1A5DD09361E3DD20E61CEB3E /* libPods-TheKeyOAuth2.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -88,7 +88,7 @@
 				D3BAC3BC1836AD9500EDE24A /* XCTest.framework */,
 				D3BAC3BF1836AD9500EDE24A /* UIKit.framework */,
 				CBEB0AEA9BB74A64BB7CDF39 /* libPods.a */,
-				02E29249FB5613E34D34ED19 /* Pods_TheKeyOAuth2.framework */,
+				5DFA7ABA8C5C33723E52B498 /* libPods-TheKeyOAuth2.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/TheKeyOAuth2/TheKeyOAuth2Client.m
+++ b/TheKeyOAuth2/TheKeyOAuth2Client.m
@@ -14,8 +14,8 @@
 
 /* TheKey OAuth2 Settings */
 static NSString *const TheKeyOAuth2ServiceProvider = @"TheKey";
-static NSString *const TheKeyOAuth2RedirectURI     = @"/oauth/client/public";
-static NSString *const TheKeyOAuth2Scope           = @"fullticket,extended";
+static NSString *const TheKeyOAuth2RedirectURI     = @"oauth/client/public";
+static NSString *const TheKeyOAuth2Scope           = @"fullticket extended";
 static NSString *const TheKeyOAuth2KeychainName    = @"TheKeyOAuth2Authentication";
 
 /* TheKey OAuth2 Endpoints */
@@ -156,10 +156,9 @@ NSString *const TheKeyOAuth2GuestGUID = @"GUEST";
 }
 
 -(TheKeyOAuth2Authentication *)newAuthenticationUsingKeychain:(BOOL)useKeychain {
-    NSString *redirectURL = [NSString stringWithFormat:@"%@%@", [[self serverURL] absoluteString], TheKeyOAuth2RedirectURI];
     TheKeyOAuth2Authentication *auth = [TheKeyOAuth2Authentication authenticationWithServiceProvider:TheKeyOAuth2ServiceProvider
                                                                                             tokenURL:[self.serverURL URLByAppendingPathComponent:TheKeyOAuth2TokenEndpoint]
-                                                                                         redirectURI:redirectURL
+                                                                                         redirectURI:[self redirectURL]
                                                                                             clientID:self.clientId
                                                                                         clientSecret:@""];
     [auth setScope:TheKeyOAuth2Scope];
@@ -192,6 +191,12 @@ NSString *const TheKeyOAuth2GuestGUID = @"GUEST";
     }
     self.loginDelegate = nil;
 }
+
+- (NSString *)redirectURL {
+    NSString *optionalSlash = [[[self serverURL] absoluteString] hasSuffix:@"/"] ? @"" : @"/";
+    return [NSString stringWithFormat:@"%@%@%@", [[self serverURL] absoluteString], optionalSlash, TheKeyOAuth2RedirectURI];
+}
+
 @end
 
 @implementation TheKeyOAuth2Authentication

--- a/TheKeyOAuth2/TheKeyOAuth2Client.m
+++ b/TheKeyOAuth2/TheKeyOAuth2Client.m
@@ -9,8 +9,8 @@
 #import "TheKeyOAuth2Client.h"
 #import "TheKeyOAuth2LoginViewController.h"
 
-#import <GTMOAuth2Authentication.h>
-#import <GTMOAuth2ViewControllerTouch.h>
+#import "GTMOAuth2Authentication.h"
+#import "GTMOAuth2ViewControllerTouch.h"
 
 /* TheKey OAuth2 Settings */
 static NSString *const TheKeyOAuth2ServiceProvider = @"TheKey";

--- a/TheKeyOAuth2/TheKeyOAuth2Client.m
+++ b/TheKeyOAuth2/TheKeyOAuth2Client.m
@@ -14,15 +14,15 @@
 
 /* TheKey OAuth2 Settings */
 static NSString *const TheKeyOAuth2ServiceProvider = @"TheKey";
-static NSString *const TheKeyOAuth2RedirectURI     = @"thekey:/oauth/mobile/ios";
-static NSString *const TheKeyOAuth2Scope           = @"fullticket";
+static NSString *const TheKeyOAuth2RedirectURI     = @"thekey:/oauth/client/public";
+static NSString *const TheKeyOAuth2Scope           = @"fullticket,extended";
 static NSString *const TheKeyOAuth2KeychainName    = @"TheKeyOAuth2Authentication";
 
-/* TheKey OAuth2 Enpoints */
+/* TheKey OAuth2 Endpoints */
 static NSString *const TheKeyOAuth2TokenEndpoint      = @"api/oauth/token";
 static NSString *const TheKeyOAuth2TicketEndpoint     = @"api/oauth/ticket";
 static NSString *const TheKeyOAuth2AttributesEndpoint = @"api/oauth/attributes";
-static NSString *const TheKeyOAuth2AuthorizeEndpoint  = @"oauth/authorize";
+static NSString *const TheKeyOAuth2AuthorizeEndpoint  = @"login";
 
 /* TheKey Notifications */
 NSString *const TheKeyOAuth2ClientDidChangeGuidNotification = @"TheKeyOAuth2ClientDidChangeGuidNotification";

--- a/TheKeyOAuth2/TheKeyOAuth2Client.m
+++ b/TheKeyOAuth2/TheKeyOAuth2Client.m
@@ -156,9 +156,10 @@ NSString *const TheKeyOAuth2GuestGUID = @"GUEST";
 }
 
 -(TheKeyOAuth2Authentication *)newAuthenticationUsingKeychain:(BOOL)useKeychain {
+    NSString *redirectURL = [NSString stringWithFormat:@"%@%@", [[self serverURL] absoluteString], TheKeyOAuth2RedirectURI];
     TheKeyOAuth2Authentication *auth = [TheKeyOAuth2Authentication authenticationWithServiceProvider:TheKeyOAuth2ServiceProvider
                                                                                             tokenURL:[self.serverURL URLByAppendingPathComponent:TheKeyOAuth2TokenEndpoint]
-                                                                                         redirectURI:TheKeyOAuth2RedirectURI
+                                                                                         redirectURI:redirectURL
                                                                                             clientID:self.clientId
                                                                                         clientSecret:@""];
     [auth setScope:TheKeyOAuth2Scope];

--- a/TheKeyOAuth2/TheKeyOAuth2Client.m
+++ b/TheKeyOAuth2/TheKeyOAuth2Client.m
@@ -14,7 +14,7 @@
 
 /* TheKey OAuth2 Settings */
 static NSString *const TheKeyOAuth2ServiceProvider = @"TheKey";
-static NSString *const TheKeyOAuth2RedirectURI     = @"thekey:/oauth/client/public";
+static NSString *const TheKeyOAuth2RedirectURI     = @"/oauth/client/public";
 static NSString *const TheKeyOAuth2Scope           = @"fullticket,extended";
 static NSString *const TheKeyOAuth2KeychainName    = @"TheKeyOAuth2Authentication";
 

--- a/TheKeyOAuth2/TheKeyOAuth2Client.m
+++ b/TheKeyOAuth2/TheKeyOAuth2Client.m
@@ -170,7 +170,7 @@ NSString *const TheKeyOAuth2GuestGUID = @"GUEST";
 
 -(void)viewController:(GTMOAuth2ViewControllerTouch *)viewController finishedWithAuth:(GTMOAuth2Authentication *)authentication error:(NSError *)error {
     if (error != nil) {
-        if (error.code != kGTMOAuth2ErrorWindowClosed && _isLoginViewPresented) {
+        if (error.code != GTMOAuth2ErrorWindowClosed && _isLoginViewPresented) {
             [viewController.presentingViewController dismissViewControllerAnimated:YES completion:^{}];
         }
         if (self.loginDelegate && [self.loginDelegate respondsToSelector:@selector(loginViewController:loginError:)]) {

--- a/TheKeyOAuth2/TheKeyOAuth2LoginViewController.h
+++ b/TheKeyOAuth2/TheKeyOAuth2LoginViewController.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 TheKey. All rights reserved.
 //
 
-#import "GTMOAuth2ViewControllerTouch.h"
+#import <GTMOAuth2/GTMOAuth2ViewControllerTouch.h>
 
 @interface TheKeyOAuth2LoginViewController : GTMOAuth2ViewControllerTouch
 


### PR DESCRIPTION
```
the measurements login activity
https://github.com/GlobalTechnology/TheKeyOAuth2/blob/master/TheKeyOAuth2/TheKeyOAuth2Client.m#L17
the new URL should be: https://thekey.me/cas/oauth/client/public
```

```
it needs to be relative to the configured base CAS url, which currently is https://thekey.me/cas or https://casdev.gcx.org/cas depending on production or stage
```

```
and this https://github.com/GlobalTechnology/TheKeyOAuth2/blob/master/TheKeyOAuth2/TheKeyOAuth2Client.m#L18 should probably be fullticket,extended now
```

```
https://github.com/GlobalTechnology/TheKeyOAuth2/blob/master/TheKeyOAuth2/TheKeyOAuth2Client.m#L25 should now be "login"
```
