### PR TITLE
POD issue with used with in SWIFT code - Missing NIB resource error.

### DIFF
--- a/TheKeyOAuth2/TheKeyOAuth2LoginViewController.m
+++ b/TheKeyOAuth2/TheKeyOAuth2LoginViewController.m
@@ -84,4 +84,10 @@
     
     return [UIImage imageNamed:@"forward" inBundle:bundle compatibleWithTraitCollection:nil];
 }
+
+// subclasses may override this to specify a custom nib bundle
+// This allows the POD to be used as a framework so that it can be used properly in SWIFT code.
++ (NSBundle *)authNibBundle {
+    return [NSBundle bundleForClass:[GTMOAuth2ViewControllerTouch class]];
+}
 @end


### PR DESCRIPTION
This allows the POD to be used as a framework so that it can be used properly in SWIFT code.