### PR TITLE
Fix right to left crash

### DIFF
--- a/TheKeyOAuth2.podspec
+++ b/TheKeyOAuth2.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name         = "TheKeyOAuth2"
-  s.version      = "0.6.8"
+  s.version      = "0.6.9"
   s.summary      = "TheKey OAuth2 Client Library."
   s.homepage     = "http://thekey.me/"
   s.license      = { :type => 'Modified BSD', :file => 'LICENSE.txt' }
   s.author       = { "Brian Zoetewey" => "brian.zoetewey@ccci.org" }
-  s.source       = { :git => "https://github.com/CruGlobal/TheKeyOAuth2.git", :tag => "0.6.8" }
+  s.source       = { :git => "https://github.com/CruGlobal/TheKeyOAuth2.git", :tag => "0.6.9" }
   s.platform     = :ios, '7.0'
   s.source_files = 'TheKeyOAuth2/*.{h,m}'
   s.public_header_files = "TheKeyOAuth2/TheKeyOAuth2Client.h", "TheKeyOAuth2/TheKeyOAuth2LoginViewController.h"

--- a/TheKeyOAuth2/TheKeyOAuth2LoginViewController.m
+++ b/TheKeyOAuth2/TheKeyOAuth2LoginViewController.m
@@ -84,7 +84,16 @@
         return true;
     }
     
-    NSString *languageCode = [locale languageCode];
+    NSString *languageCode;
+    
+    if (@available(iOS 10, *)) {
+        languageCode = [locale languageCode];
+    } else {
+        NSString *language = [[NSLocale preferredLanguages] objectAtIndex:0];
+        NSDictionary *languageDic = [NSLocale componentsFromLocaleIdentifier:language];
+        languageCode = [languageDic objectForKey:@"kCFLocaleLanguageCodeKey"];
+    }
+    
     if (!languageCode) {
         return true;
     }

--- a/TheKeyOAuth2/TheKeyOAuth2LoginViewController.m
+++ b/TheKeyOAuth2/TheKeyOAuth2LoginViewController.m
@@ -77,8 +77,23 @@
     self.navigationItem.rightBarButtonItems = @[self.forwardBarButtonItem, self.backBarButtonItem];
 }
 
+/* defaults to true if locale or language code cannot be determined */
 -(bool)isLeftToRightLanguage {
-    return ![@"ar" isEqualToString:[[NSLocale currentLocale] languageCode]];
+    NSLocale *locale = [NSLocale currentLocale];
+    if (!locale) {
+        return true;
+    }
+    
+    NSString *languageCode = [locale languageCode];
+    if (!languageCode) {
+        return true;
+    }
+    
+    if (![languageCode respondsToSelector:@selector(isEqualToString:)]) {
+        return true;
+    }
+    
+    return ![languageCode isEqualToString:@"ar"];
 }
 
 -(UIImage *)leftChevronImage {


### PR DESCRIPTION
There are a very few number of crashes since this change was introduced. The reason is probably because:
````objc
[[NSLocale currentLocale] languageCode]]
````
is only available on iOS 10.0+ and for some reason XCode didn't show a warning earlier.

The example crashes are here: https://fabric.io/cru/ios/apps/org.cru.mpdx/issues/5a4668608cb3c2fa63df3219?time=last-thirty-days